### PR TITLE
Enabling API Proxy pass through

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ var browserify = require('browserify')
 var reactify = require('reactify')
 var del = require('del')
 var NwBuilder = require('node-webkit-builder')
-var ipfs_static = require('ipfs-node-server-static')('localhost', 5001);
+var ipfs_static = require('ipfs-node-server-static')('localhost', 5001, {api: true});
 
 var paths = {
   build: 'build/',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-sourcemaps": "^1.2.2",
     "gulp-uglify": "^1.0.1",
-    "ipfs-node-server-static": "^1.0.2",
+    "ipfs-node-server-static": "^1.1.0",
     "node-webkit-builder": "^0.1.3",
     "react-bootstrap": "^0.12.0",
     "react-tools": "^0.11.2",


### PR DESCRIPTION
*In my previous pull request I forgot to commit and push some last minute changes I made, so currently the fix to allow the gulp server to proxy api requests forward to ipfs is not enabled, nor was it in the module version published to npm*

---

This is an enabled version.

I am however, not sure if this is going to stay in this package or how long this package is going to be alive as simple using many of the available proxy pass middleware solves both the issues.

I have found a simpler solution that should work, but does not due to a refereral header.

Using: https://www.npmjs.com/package/proxy-middleware
```
    livereload: true,
    middleware: function(connect, opts) {
      var apiProxy = url.parse("http://127.0.0.1:5001/api")
      apiProxy.route = "/api"
      var ipfsProxy = url.parse("http://127.0.0.1:8080/ipfs")
      ipfsProxy.route = "/ipfs"
      return [apiProxy, ipfsProxy]
    }
```
*Not fully tested as written from memory*

The issue with this is that the IPFS API [does not allow the referer to be different](https://github.com/jbenet/go-ipfs/blob/0de13b071db8b9cfb49a8ee3ac791e232b0e607a/commands/http/handler.go#L60).

This is easily solved, but I have yet to find a module that will do this on it's own. Writing a simple middleware is a solution, for now though updating to the new version of `ipfs-node-server-static` and enabling the API pass through might be an easy solution.