### PR TITLE
When the webui is running on port 80, it will not have an undefined port

### DIFF
--- a/js/views/page.jsx
+++ b/js/views/page.jsx
@@ -4,7 +4,7 @@ var RouteHandler = require('react-router').RouteHandler
 var Link = require('react-router').Link
 
 var host = window.location.hostname
-var port = window.location.port
+var port = window.location.port || 80
 if(localStorage.daemon) {
   host = localStorage.daemon.host
   port = localStorage.daemon.port


### PR DESCRIPTION
`window.location.port` will return `undefined` when no part is specified
on the url. This happens for port 80 as it's a default and not required.

This ends up with undefined being passed to the IPFS API, to which it
responds by using the default 5001.

This fixes #4 