### PR TITLE
Cleans the directory prior to a new building being published

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build/static/bundle.min.js: $(gulp) $(shell find js html less)
 $(gulp):
 	npm install
 
-publish: build
+publish: clean build
 	ipfs add -r -q build | tail -n1 >versions/current
 	cp -r static versions/`cat versions/current`
 	cat versions/current >>versions/history


### PR DESCRIPTION
This fixes issue #11 to ensure that prior to doing a publish we have a clean build directory and we don't pull in any extra files.